### PR TITLE
Add fixed delay after reseting device

### DIFF
--- a/pygatt/backends/bgapi/bgapi.py
+++ b/pygatt/backends/bgapi/bgapi.py
@@ -208,6 +208,10 @@ class BGAPIBackend(BLEBackend):
             self.send_command(CommandBuilder.system_reset(0))
             self._ser.close()
 
+            # Wait before re-opening the port - required on at least Windows,
+            # possibly OS X.
+            time.sleep(1)
+
         self._open_serial_port()
         self._receiver = threading.Thread(target=self._receive)
         self._receiver.daemon = True


### PR DESCRIPTION
This is to mirror the changes made in peplin/pygatt repo to get BLE112 working on Mac OS.

https://github.com/peplin/pygatt/blob/57a47ca20620e9e9ffd413f01c5a552a3b3cf082/pygatt/backends/bgapi/bgapi.py#L220